### PR TITLE
fix compilation with armcc

### DIFF
--- a/nanostack-event-loop/platform/arm_hal_timer.h
+++ b/nanostack-event-loop/platform/arm_hal_timer.h
@@ -16,7 +16,8 @@ extern void platform_timer_enable(void);
  * \param new_fp Function pointer for stack giving timer handler
  *
  */
-extern void platform_timer_set_cb(void (*new_fp)(void));
+typedef void (*platform_timer_cb)(void);
+extern void platform_timer_set_cb(platform_timer_cb new_fp);
 /**
  * \brief This function is API for stack timer start
  *


### PR DESCRIPTION
It's necessary to use a typedef for a function pointer-type argument of an
extern-C function, otherwise extern-c is not correctly applied to the
argument's type, resulting in a linker error.
