### PR TITLE
Use event id 0 for initialization event

### DIFF
--- a/source/event.c
+++ b/source/event.c
@@ -109,6 +109,7 @@ int8_t eventOS_event_handler_create(void (*handler_func_ptr)(arm_event_s *), uin
     event_tmp->data.receiver = new->id;
     event_tmp->data.sender = 0;
     event_tmp->data.event_type = init_event_type;
+    event_tmp->data.event_id = 0;
     event_tmp->data.event_data = 0;
     event_core_write(event_tmp);
 


### PR DESCRIPTION
Some event handlers incorrectly check that event_id is 0 for initialization event. Even though
documentation does not mention that id is zeroed for initialization event, it is better to have some
init value instead of a random value. As eventloop has internal list of events, some old event id can
be used if id is not initialized.